### PR TITLE
feat(dwolla-transfer): add individualAchId to transfer response model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>dwolla-swagger-java</artifactId>
   <packaging>jar</packaging>
   <name>dwolla-swagger-java</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <scm>
     <connection>scm:git:git@github.com:swagger-api/swagger-mustache.git</connection>
     <developerConnection>scm:git:git@github.com:swagger-api/swagger-codegen.git</developerConnection>

--- a/src/main/java/io/swagger/client/model/Transfer.java
+++ b/src/main/java/io/swagger/client/model/Transfer.java
@@ -23,6 +23,8 @@ public class Transfer  {
   private Date created = null;
   private Object metadata = null;
   private String locationHeader;
+  private String individualAchId = null;
+
 
 
   
@@ -111,6 +113,19 @@ public class Transfer  {
 
   
 
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("individualAchId")
+  public String getIndividualAchId() {
+    return individualAchId;
+  }
+  public void setIndividualAchId(String individualAchId) {
+    this.individualAchId = individualAchId;
+  }
+
+
+
 
   /**
    * Used to deserialize Location field in
@@ -133,6 +148,7 @@ public class Transfer  {
     sb.append("  amount: ").append(amount).append("\n");
     sb.append("  created: ").append(created).append("\n");
     sb.append("  metadata: ").append(metadata).append("\n");
+    sb.append("  individualAchId: ").append(individualAchId).append("\n");
     sb.append("}\n");
     return sb.toString();
   }


### PR DESCRIPTION
A new attribute, individualAchId, has been added to Transfer API.

This attribute will essentially be a unique string value that will be a total of 8 characters which is including an additional `I` prefix character. individualAchId will be returned when retrieving a unique transfer via the API. Note: This attribute will be returned on transfers where funds are moving into the Dwolla network from a bank and out of the Dwolla network to a bank. This value will be passed along on our ACH file in the Individual Id field, which should be displayed by the receiving and/or sending bank account.